### PR TITLE
upgrade antlr version

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -100,7 +100,7 @@
     <org.bouncycastle.version>1.69</org.bouncycastle.version>
 
     <!-- code generation -->
-    <org.antlr4.version>4.9.2</org.antlr4.version>
+    <org.antlr4.version>4.10.1</org.antlr4.version>
     <com.sun.codemodel.version>2.6</com.sun.codemodel.version>
 
     <!-- software-languages -->


### PR DESCRIPTION
Upgraded antlr version from 4.9.2 to 4.10.1.
Ran tests with `mvn clean package -f commons/tools/pom.xml`.

Already generated parsers should be regenerated, see: https://github.com/antlr/antlr4/releases/tag/4.10 "4.10-generated parsers incompatible with previous runtimes".